### PR TITLE
feat(ntfy): build as apk instead of aab

### DIFF
--- a/.github/workflows/ntfy-app.yml
+++ b/.github/workflows/ntfy-app.yml
@@ -25,6 +25,12 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      - name: Install build tools
+        run: |
+          wget -O android-build-tools.zip https://dl.google.com/android/repository/build-tools_r33.0.2-linux.zip
+          unzip -q android-build-tools.zip
+          echo "$(pwd)/android-13" >> $GITHUB_PATH
+
       - name: Import Google services file
         run: echo "$GOOGLE_SERVICES" > app/google-services.json
         env:

--- a/.github/workflows/ntfy-app.yml
+++ b/.github/workflows/ntfy-app.yml
@@ -39,15 +39,18 @@ jobs:
         run: sed -i "s|https://ntfy.sh|https://notify.krantz.cloud|g" app/src/main/res/values/values.xml
 
       - name: Build
-        run: ./gradlew bundlePlayRelease
+        run: ./gradlew assemblePlayRelease
 
-      - name: Sign
-        run: jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release.jks -storepass "$STORE_PASSWORD" app/build/outputs/bundle/playRelease/app-play-release.aab ntfy
-        env:
-          STORE_PASSWORD: ${{ secrets.APK_RELEASE_KEYSTORE_PASSWORD }}
+      - run: find . -type f -name '*.apk'
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ntfy.aab
-          path: app/build/outputs/bundle/playRelease/app-play-release.aab
-          if-no-files-found: error
+      # - name: Sign
+      #   run: |
+      #     jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release.jks -storepass "$STORE_PASSWORD" app/build/outputs/bundle/playRelease/app-play-release.aab ntfy
+      #   env:
+      #     STORE_PASSWORD: ${{ secrets.APK_RELEASE_KEYSTORE_PASSWORD }}
+
+      # - uses: actions/upload-artifact@v3
+      #   with:
+      #     name: ntfy.aab
+      #     path: app/build/outputs/bundle/playRelease/app-play-release.aab
+      #     if-no-files-found: error

--- a/.github/workflows/ntfy-app.yml
+++ b/.github/workflows/ntfy-app.yml
@@ -41,16 +41,16 @@ jobs:
       - name: Build
         run: ./gradlew assemblePlayRelease
 
-      - run: find . -type f -name '*.apk'
+      - name: Sign
+        run: |
+          zipalign -v -p 4 app/build/outputs/apk/play/release/app-play-release-unsigned.apk app/build/outputs/apk/play/release/app-play-release-unsigned-aligned.apk
+          apksigner sign --ks release.jks --ks-pass "pass:$STORE_PASSWORD" --ks-key-alias ntfy --out app/build/outputs/apk/play/release/app-play-release.apk app/build/outputs/apk/play/release/app-play-release-unsigned-aligned.apk
+          apksigner verify app/build/outputs/apk/play/release/app-play-release.apk
+        env:
+          STORE_PASSWORD: ${{ secrets.APK_RELEASE_KEYSTORE_PASSWORD }}
 
-      # - name: Sign
-      #   run: |
-      #     jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore release.jks -storepass "$STORE_PASSWORD" app/build/outputs/bundle/playRelease/app-play-release.aab ntfy
-      #   env:
-      #     STORE_PASSWORD: ${{ secrets.APK_RELEASE_KEYSTORE_PASSWORD }}
-
-      # - uses: actions/upload-artifact@v3
-      #   with:
-      #     name: ntfy.aab
-      #     path: app/build/outputs/bundle/playRelease/app-play-release.aab
-      #     if-no-files-found: error
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ntfy.apk
+          path: app/build/outputs/apk/play/release/app-play-release.apk
+          if-no-files-found: error

--- a/.github/workflows/ntfy-app.yml
+++ b/.github/workflows/ntfy-app.yml
@@ -45,9 +45,13 @@ jobs:
         run: |
           zipalign -v -p 4 app/build/outputs/apk/play/release/app-play-release-unsigned.apk app/build/outputs/apk/play/release/app-play-release-unsigned-aligned.apk
           apksigner sign --ks release.jks --ks-pass "pass:$STORE_PASSWORD" --ks-key-alias ntfy --out app/build/outputs/apk/play/release/app-play-release.apk app/build/outputs/apk/play/release/app-play-release-unsigned-aligned.apk
-          apksigner verify app/build/outputs/apk/play/release/app-play-release.apk
         env:
           STORE_PASSWORD: ${{ secrets.APK_RELEASE_KEYSTORE_PASSWORD }}
+
+      - name: Verify
+        run: |
+          zipalign -c -v 4 app/build/outputs/apk/play/release/app-play-release.apk
+          apksigner verify app/build/outputs/apk/play/release/app-play-release.apk
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -5,6 +5,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/templates.yml
+      - templates/**
 
 jobs:
   publish:


### PR DESCRIPTION
Updates the build process to create an APK instead of an AAB so that the artifact can be easily installed without ADB.