### PR TITLE
Add tailfed project resources

### DIFF
--- a/terraform/github-actions/identity.tf
+++ b/terraform/github-actions/identity.tf
@@ -18,7 +18,8 @@ resource "aws_iam_role_policy_attachments_exclusive" "homelab" {
     data.aws_iam_policy.kms_full_access.arn,
     data.aws_iam_policy.s3_full_access.arn,
     data.aws_iam_policy.ses_full_access.arn,
-    data.aws_iam_policy.cloudfront_full_access.arn
+    data.aws_iam_policy.cloudfront_full_access.arn,
+    data.aws_iam_policy.ecrpublic_full_access.arn,
   ]
 }
 
@@ -69,4 +70,8 @@ data "aws_iam_policy" "ses_full_access" {
 
 data "aws_iam_policy" "cloudfront_full_access" {
   name = "CloudFrontFullAccess"
+}
+
+data "aws_iam_policy" "ecrpublic_full_access" {
+  name = "AmazonElasticContainerRegistryPublicFullAccess"
 }

--- a/terraform/github-actions/main.tf
+++ b/terraform/github-actions/main.tf
@@ -12,3 +12,7 @@ terraform {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/terraform/github-actions/project-homelab.tf
+++ b/terraform/github-actions/project-homelab.tf
@@ -1,7 +1,3 @@
-data "aws_iam_openid_connect_provider" "github" {
-  url = "https://token.actions.githubusercontent.com"
-}
-
 resource "aws_iam_role" "homelab" {
   name        = "GitHubActionsHomelab"
   description = "The role assumed by the akrantz01/homelab repository on GitHub."

--- a/terraform/github-actions/project-tailfed.tf
+++ b/terraform/github-actions/project-tailfed.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role" "tailfed" {
+  name        = "GitHubActionsTailfed"
+  description = "The role assumed by the akrantz01/tailfed repository on GitHub."
+
+  assume_role_policy = data.aws_iam_policy_document.tailfed_trust_policy.json
+}
+
+resource "aws_iam_role_policy" "tailfed_ecr" {
+  name = "GitHubActionsTailfedECR"
+  role = aws_iam_role.tailfed.id
+
+  policy = data.aws_iam_policy_document.tailfed_ecr_policy.json
+}
+
+data "aws_iam_policy_document" "tailfed_trust_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:akrantz01/tailfed:ref:refs/heads/*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "tailfed_ecr_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr-public:GetAuthorizationToken",
+      "sts:GetServiceBearerToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr-public:BatchCheckLayerAvailability",
+      "ecr-public:CompleteLayerUpload",
+      "ecr-public:InitiateLayerUpload",
+      "ecr-public:PutImage",
+      "ecr-public:UploadLayerPart",
+    ]
+    resources = [
+      "arn:aws:ecr-public::${data.aws_caller_identity.current.account_id}:repository/tailfed/*"
+    ]
+  }
+}

--- a/terraform/github-actions/secrets.tf
+++ b/terraform/github-actions/secrets.tf
@@ -1,4 +1,4 @@
-resource "github_actions_secret" "aws_assume_role" {
+resource "github_actions_secret" "homelab_aws_assume_role" {
   repository      = "homelab"
   secret_name     = "AWS_ASSUME_ROLE_ARN"
   plaintext_value = aws_iam_role.homelab.arn

--- a/terraform/github-actions/secrets.tf
+++ b/terraform/github-actions/secrets.tf
@@ -3,3 +3,10 @@ resource "github_actions_secret" "aws_assume_role" {
   secret_name     = "AWS_ASSUME_ROLE_ARN"
   plaintext_value = aws_iam_role.homelab.arn
 }
+
+resource "github_actions_secret" "tailfed_aws_assume_role" {
+  repository      = "tailfed"
+  secret_name     = "AWS_ASSUME_ROLE_ARN"
+  plaintext_value = aws_iam_role.tailfed.arn
+}
+

--- a/terraform/projects/tailfed/.terraform.lock.hcl
+++ b/terraform/projects/tailfed/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.94.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:RXSLJMRLEhUqHEqZd0/Xg849Kiou4reEcunSLjnlGek=",
+    "zh:17fa3264940caf41e83ed26b791ff8197576af23a24aab4fe717c27f2ecf0c93",
+    "zh:2f2ceff112db49542c8fb93a0d01c480b6b8be71a792b5675b6f3cac1b93cccf",
+    "zh:4aa15c4ea935c03ec5a51378d9076a1fd71e53b36c94191bcbfa81a9c75b9b42",
+    "zh:7a3913086814004d44309b860d1596a78633cff3f98adfb1639433c7c64d6682",
+    "zh:7b4f816e608529288dcf84e54f555f585367a99ee7e5f70e08ffab69cc5a7e6a",
+    "zh:81539e502099eddf8f69ce74906ade95f39addcfedeb6adab008df7ca325a827",
+    "zh:89930b745bd45ad547eaf8cd734c148665c3f0915692ad773414b2407d14139b",
+    "zh:c083cab919b58943ac87fcc44bf49a6c0aad54e9302986a9d03fedd82f545ed2",
+    "zh:d6ac2a98456d632e47fee0fdb45f29f5c4b661a2d11519344c9dbf565d18f92e",
+    "zh:d9665bc66772d358e7ea3f015a2279e69dff52158d42a5313599a4d0043a53b2",
+  ]
+}

--- a/terraform/projects/tailfed/ecr.tf
+++ b/terraform/projects/tailfed/ecr.tf
@@ -1,0 +1,16 @@
+resource "aws_ecrpublic_repository" "lambda" {
+  for_each = var.repositories
+
+  repository_name = "tailfed/${each.key}"
+
+  catalog_data {
+    description = "Tailfed ${title(each.key)} Lambda Image"
+    about_text  = <<-EOA
+    The Lambda image for the ${each.key} component of the [Tailfed](https://github.com/akrantz01/tailfed) API.
+    It is ${each.value}
+    EOA
+
+    operating_systems = ["Linux"]
+    architectures     = ["x86-64", "ARM 64"]
+  }
+}

--- a/terraform/projects/tailfed/main.tf
+++ b/terraform/projects/tailfed/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/projects/tailfed/terragrunt.hcl
+++ b/terraform/projects/tailfed/terragrunt.hcl
@@ -1,0 +1,17 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "github-actions" {
+  config_path = "../../github-actions"
+
+  skip_outputs = true
+}
+
+inputs = {
+  repositories = {
+    initializer = "an API gateway handler for starting a device verification flow."
+    verifier    = "a step function component responsible for verifying the challenge given by the initializer Lambda."
+    finalizer   = "an API gateway handler for issuing the token once a device has been successfully verified."
+  }
+}

--- a/terraform/projects/tailfed/variables.tf
+++ b/terraform/projects/tailfed/variables.tf
@@ -1,0 +1,4 @@
+variable "repositories" {
+  type        = map(string)
+  description = "The repositories to create with their descriptions"
+}


### PR DESCRIPTION
Adds resources for the Tailfed project (unreleased). Includes multiple ECR public repositories for the Lambda images and GitHub Actions assume role for publishing to the repositories.